### PR TITLE
Fix i18n initialization typing

### DIFF
--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1,4 +1,4 @@
-import i18n from 'i18next';
+import i18n, { type InitOptions } from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import Backend from 'i18next-http-backend';
@@ -12,31 +12,33 @@ i18n
   // Intégration avec React
   .use(initReactI18next)
   // Initialisation
-  .init({
-    fallbackLng: import.meta.env.VITE_DEFAULT_LANGUAGE || 'fr',
-    debug: import.meta.env.DEV,
-    defaultNS: 'common',
-    ns: ['common', 'contact', 'home', 'projects', 'about'],
-    interpolation: {
-      escapeValue: false,
-    },
-    detection: {
-      order: ['querystring', 'cookie', 'localStorage', 'navigator', 'htmlTag'],
-      lookupQuerystring: 'lng',
-      lookupCookie: 'i18next',
-      lookupLocalStorage: 'i18nextLng',
-      cookieDomain: 'localhost',
-      cookieExpirationDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
-      cookiePath: '/',
-      cookieSecure: false,
-    },
-    backend: {
-      loadPath: '/locales/{{lng}}/{{ns}}.json',
-    },
-    react: {
-      wait: true,
-      useSuspense: true,
-    },
-  });
+  .init(
+    {
+      fallbackLng: import.meta.env.VITE_DEFAULT_LANGUAGE || 'fr',
+      debug: import.meta.env.DEV,
+      defaultNS: 'common',
+      ns: ['common', 'contact', 'home', 'projects', 'about'],
+      interpolation: {
+        escapeValue: false,
+      },
+      detection: {
+        order: ['querystring', 'cookie', 'localStorage', 'navigator', 'htmlTag'],
+        lookupQuerystring: 'lng',
+        lookupCookie: 'i18next',
+        lookupLocalStorage: 'i18nextLng',
+        cookieDomain: 'localhost',
+        cookieExpirationDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
+        cookiePath: '/',
+        cookieSecure: false,
+      },
+      backend: {
+        loadPath: '/locales/{{lng}}/{{ns}}.json',
+      },
+      react: {
+        wait: true,
+        useSuspense: true,
+      },
+    } satisfies InitOptions,
+  );
 
 export default i18n;


### PR DESCRIPTION
## Summary
- ensure options passed to `i18n.init` satisfy `InitOptions`
